### PR TITLE
Replace API key with env variable

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -100,6 +100,12 @@ cd Frontend
 npm install
 ```
 
+4. Create a `.env` file in the `Frontend` directory and add your Gemini API key:
+```bash
+REACT_APP_GEMINI_API_KEY=your_api_key_here
+```
+The `.env` file is already listed in `.gitignore` so it will not be committed to version control.
+
 ## Running the Application
 
 To start the development server:

--- a/Frontend/src/pages/CommunityPages/CounsellorBotChat.js
+++ b/Frontend/src/pages/CommunityPages/CounsellorBotChat.js
@@ -24,7 +24,7 @@ export default function CounsellorBotChat() {
       User: ${input}`;      
 
 
-      const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=AIzaSyATesepFKDuKiy3erERfUg2FqsSYOWEn9A', {
+      const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${process.env.REACT_APP_GEMINI_API_KEY}` , {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- replace hardcoded key with `process.env.REACT_APP_GEMINI_API_KEY`
- document `.env` usage in frontend README

## Testing
- `npm test --prefix Frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684739a9c4988326b192e763dd4e955d